### PR TITLE
WIP: add a dry-run mode

### DIFF
--- a/example.py
+++ b/example.py
@@ -43,6 +43,11 @@ def python():
     run('python')
 
 
+@minicli.wrap
+def wrapper(hostname, dry_run):
+    with connect(hostname=hostname, dry_run=dry_run):
+        yield
+
+
 if __name__ == '__main__':
-    with connect('usine'):
-        minicli.run()
+    minicli.run(hostname='usine', dry_run=False)

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -1,4 +1,5 @@
 import pytest
+import usine
 from usine import cd, cp, env, exists, ls, mkdir, mv, run
 
 
@@ -131,3 +132,13 @@ def test_quoting(connection):
     assert res.stdout == '''pouet with 'quotes'\r\n'''
     res = run("echo \"pouet with \\'quotes\\'\"")
     assert res.stdout == '''pouet with 'quotes'\r\n'''
+
+
+def test_dry_run(connection):
+    path = '/tmp/usinetestfile'
+    run(f'rm {path} || exit 0')
+    assert not exists(path)
+    usine.client.dry_run = True
+    run(f'touch {path}')
+    usine.client.dry_run = False
+    assert not exists(path)

--- a/tests/integration/test_sftp.py
+++ b/tests/integration/test_sftp.py
@@ -2,7 +2,8 @@ from io import BytesIO, StringIO
 from pathlib import Path
 
 import pytest
-from usine import cd, get, put, run
+import usine
+from usine import cd, get, put, run, exists
 
 
 @pytest.fixture(scope='module')
@@ -74,3 +75,11 @@ def test_get_with_cd(remotefile):
         data = BytesIO()
         get('usinetestget', data)
         assert data.read().decode() == 'foobarééœ'
+
+
+def test_dry_run(connection):
+    remote = '/tmp/usinetestdryrun'
+    usine.client.dry_run = True
+    put(Path(__file__).parent / 'test.txt', remote)
+    usine.client.dry_run = False
+    assert not exists(remote)


### PR DESCRIPTION
The concept is appealing, but perfidious: while we'd like the dry_run
mode to only print the command without doing anything, those command
actually need to return a status, and this status may be used for logical
decisions on the user code that could actually do things.