### PR TITLE
First naive support for proxy command

### DIFF
--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -82,3 +82,18 @@ if __name__ == '__main__':
 And you can run it like this:
 
     myscript.py foo --force --hostname production
+
+
+# How to use proxy command
+
+You can define a SSH proxy command through the config:
+
+```yml
+proxy_command: ssh -q user@bastion -W remote_host:22
+username: remote_user
+hostname: remote_host
+```
+
+This will connect to `remote_host` through `bastion` host.
+Note: when using `proxy_command`, `username` and `hostname` should reflect the
+host and user of the target machine (not the proxy server).

--- a/tests/integration/test_connect.py
+++ b/tests/integration/test_connect.py
@@ -1,0 +1,7 @@
+from usine import connect, config, run
+
+
+def test_proxy_command():
+    config.proxy_command = 'ssh -q usine -W 127.0.0.1:22'
+    with connect(hostname='ubuntu@127.0.0.1'):
+        assert 'ubuntu' in run('whoami')

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -13,8 +13,7 @@ def test_config_should_proxy_dict():
 def test_config_should_swallow_missing_keys():
     config = Config()
     assert not config
-    assert not config.missing
-    assert not config.missing.again
+    assert config.missing is None
 
 
 def test_config_setattr():

--- a/usine.py
+++ b/usine.py
@@ -50,58 +50,17 @@ class RemoteError(Exception):
     pass
 
 
-class Config:
-
-    def __init__(self, value=None):
-        if isinstance(value, Config):
-            value = value.value
-        super().__setattr__('value', value or {})
-
-    def get(self, key, default=None):
-        try:
-            return Config(self.value.get(key, default))
-        except AttributeError:
-            return Config(default)
-
-    def __getitem__(self, key):
-        if isinstance(key, int):
-            return self.value.__getitem__(key)
-        return self.__getattr__(key)
+class Config(dict):
 
     def __getattr__(self, key):
-        try:
-            return Config(self.value.get(key))
-        except AttributeError:
-            return Config()
+        value = self.get(key)
+        # Allow to chain getattr (eg. config.foo.bar)
+        if isinstance(value, dict):
+            value = Config(value)
+        return value
 
     def __setattr__(self, key, value):
-        self.value[key] = value
-
-    def __str__(self):
-        return str(self.value)
-
-    def __eq__(self, other):
-        return other == self.value
-
-    # https://eev.ee/blog/2012/03/24/python-faq-equality/
-    # No way to override "is" behaviour, so no way to do "config.key is None"…
-    def __bool__(self):
-        return bool(self.value)
-
-    def __hash__(self):
-        return hash(self.value)
-
-    def __iter__(self):
-        return iter(self.value)
-
-    def items(self):
-        return self.value.items()
-
-    def update(self, other):
-        self.value.update(other)
-
-    def keys(self):
-        return self.value.keys()
+        self[key] = value
 
 
 config = Config()  # singleton.

--- a/usine.py
+++ b/usine.py
@@ -229,7 +229,8 @@ class Client:
         self.screen = None
         self.env = {}
         self._sftp = None
-        self.proxy_command = config.proxy_command or None
+        self.proxy_command = ssh_config.get('proxycommand',
+                                            config.proxy_command)
         self.open()
 
     def open(self):

--- a/usine.py
+++ b/usine.py
@@ -179,9 +179,9 @@ class Client:
             ssh_config.parse(fd)
         ssh_config = ssh_config.lookup(hostname)
         self.dry_run = dry_run
-        self.hostname = str(config.hostname or ssh_config['hostname'])
-        self.username = str(username or config.username
-                            or ssh_config.get('user', getuser()))
+        self.hostname = config.hostname or ssh_config['hostname']
+        self.username = (username or config.username
+                         or ssh_config.get('user', getuser()))
         self.formatter = Formatter()
         self.sudo = ''
         self.cd = None
@@ -199,7 +199,7 @@ class Client:
         print(f'Connecting to {self.username}@{self.hostname}')
         if self.proxy_command:
             print('ProxyCommand:', self.proxy_command)
-        sock = (paramiko.ProxyCommand(str(self.proxy_command))
+        sock = (paramiko.ProxyCommand(self.proxy_command)
                 if self.proxy_command else None)
         try:
             self._client.connect(hostname=self.hostname,


### PR DESCRIPTION
Changes:
- proxy_command is read from config or from ssh config (which is I think the most common use case)
- hostname and username are read from the config if available (allows to have alias hostname like "prod" and "test" which then map to config keys)
- the config magic where every config key returns a config instance is removed: too much side effects; now we only return a config when a key is a dict, so we still can do `config.key.other`