### PR TITLE
Proper way to undo a sudo context

### DIFF
--- a/tests/unit/test_command.py
+++ b/tests/unit/test_command.py
@@ -54,3 +54,21 @@ def test_ls_without_all(patch_client):
 def test_ls_without_list(patch_client):
     assert usine.ls('/tmp/foo', list=False) == \
         "sh -c $'ls --all --human-readable --size /tmp/foo'"
+
+
+def test_sudo(patch_client):
+    with usine.sudo():
+        assert usine.run('whoami') == \
+            "sudo --set-home --preserve-env  sh -c $'whoami'"
+
+
+def test_sudo_user(patch_client):
+    with usine.sudo(user="me"):
+        assert usine.run('whoami') == \
+            "sudo --set-home --preserve-env --user=me --login sh -c $'whoami'"
+
+
+def test_unsudo(patch_client):
+    with usine.sudo():
+        with usine.unsudo():
+            assert usine.run('whoami') == "sh -c $'whoami'"

--- a/usine.py
+++ b/usine.py
@@ -157,6 +157,9 @@ class Status:
     def __str__(self):
         return self.stdout
 
+    def __repr__(self):
+        return str(self)[:100] + "…"
+
     def __bool__(self):
         return self.code == 0
 
@@ -402,7 +405,7 @@ def put(local, remote, force=False):
     if not hasattr(local, 'read'):
         local = Path(local)
         if local.is_dir():
-            with sudo():  # Force reset to SSH user.
+            with unsudo():  # Force reset to SSH user.
                 mkdir(remote)
                 if user:
                     chown(user, remote)
@@ -440,7 +443,7 @@ def put(local, remote, force=False):
         sys.exit(1)
     if hasattr(local, 'read'):
         bar.finish()
-    with sudo():  # Force reset to SSH user.
+    with unsudo():  # Force reset to SSH user.
         mv(tmp, remote)
         if user:
             chown(user, remote)
@@ -484,6 +487,14 @@ def sudo(set_home=True, preserve_env=True, user=None, login=None):
     yield
     client.sudo = previous
     client.context = previous_context
+
+
+@contextmanager
+def unsudo():
+    previous = client.sudo
+    client.sudo = None
+    yield
+    client.sudo = previous
 
 
 @contextmanager


### PR DESCRIPTION
Before, we were doing a sudo of the ssh user on itself, now we properly remove any sudo.